### PR TITLE
fix output so pry cli is on its own line

### DIFF
--- a/lib/pry-awesome_print.rb
+++ b/lib/pry-awesome_print.rb
@@ -1,5 +1,5 @@
 require 'pry'
 require 'awesome_print'
 Pry.print = proc { |output, value|
-  Pry::Helpers::BaseHelpers.stagger_output("=> #{value.ai}", output)
+  Pry::Helpers::BaseHelpers.stagger_output("=> #{value.ai}\n", output)
 }


### PR DESCRIPTION
Otherwise you end up with something like this:

```
[1] pry(main)> "foo"
=> "foo"[2] pry(main)>
```

When it should look like this:

```
[1] pry(main)> "foo"
=> "foo"
[2] pry(main)>
```